### PR TITLE
Fix: TypeError: Cannot read property '1' of undefined

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -527,7 +527,7 @@ Client.prototype.createBroker = function connect(host, port, longpolling) {
     });
     socket.on('close', function (had_error) {
         self.emit('close', this);
-        if (had_error) {
+        if (had_error && this.error) {
             self.clearCallbackQueue(this, this.error);
         }
         else {


### PR DESCRIPTION
While refreshing metadata it's possible for the socket connection to be closed with had_error = true but this.error = null.

This leads to clearCallbackQueue being run with a 'null' error.

In turn, this leads to the loadMetadata callback in refreshMetadata being invoked with err = null and resp = undefined thus it tries to extract an error with:-

err = err || resp[1].error 

Since resp is undefined due to the above then it leads to an uncaught TypeError "Cannot read property '1' of undefined".

(Extra debugging added:)
1. Consumer closes the connection
   2016-02-04T14:11:28.026Z - debug: kafka-node:Consumer connection closed
2. socket had_error = true but this.error = null
   2016-02-04T14:11:28.026Z - debug: kafka-node:Client socket had_error: true
   2016-02-04T14:11:28.026Z - debug: kafka-node:Client this.error: null
3. Callback invoked in refreshMetadata with err = null and resp = undefined:
   2016-02-04T14:11:28.026Z - debug: kafka-node:Client err: null
   2016-02-04T14:11:28.026Z - debug: kafka-node:Client resp: undefined
4. The TypeError:-

2016-02-04T14:11:28.029Z - error: uncaughtException: Cannot read property '1' of undefined date=Thu Feb 04 2016 08:11:28 GMT-0600 (CST), pid=28937, uid=25193, gid=9050, cwd=/, execPath=/usr/bin/nodejs, version=v0.10.26, argv=[/usr/bin/nodejs, /usr/local/bin/REDACTED, -c, /usr/local/etc/REDACTED.conf.js], rss=128045056, heapTotal=70583040, heapUsed=36950992, loadavg=[1.70703125, 1.771484375, 1.515625], uptime=19867997.273263227, trace=[column=34, file=/usr/local/lib/node_modules/REDACTED/node_modules/kafka-node/lib/client.js, function=null, line=357, method=null, native=false, column=13, file=/usr/local/lib/node_modules/REDACTED/node_modules/kafka-node/lib/client.js, function=null, line=629, method=null, native=false, column=null, file=null, function=Array.forEach, line=null, method=forEach, native=true, column=28, file=/usr/local/lib/node_modules/REDACTED/node_modules/kafka-node/lib/client.js, function=Client.clearCallbackQueue, line=626, method=clearCallbackQueue, native=false, column=18, file=/usr/local/lib/node_modules/REDACTED/node_modules/kafka-node/lib/client.js, function=, line=525, method=null, native=false, column=17, file=events.js, function=Socket.EventEmitter.emit, line=95, method=EventEmitter.emit, native=false, column=12, file=net.js, function=TCP.close, line=465, method=close, native=false], stack=[TypeError: Cannot read property '1' of undefined,     at /usr/local/lib/node_modules/REDACTED/node_modules/kafka-node/lib/client.js:357:34,     at /usr/local/lib/node_modules/REDACTED/node_modules/kafka-node/lib/client.js:629:13,     at Array.forEach (native),     at Client.clearCallbackQueue (/usr/local/lib/node_modules/REDACTED/node_modules/kafka-node/lib/client.js:626:28),     at Socket.<anonymous> (/usr/local/lib/node_modules/REDACTED/node_modules/kafka-node/lib/client.js:525:18),     at Socket.EventEmitter.emit (events.js:95:17),     at TCP.close (net.js:465:12)]
